### PR TITLE
Serial2

### DIFF
--- a/Block.pde
+++ b/Block.pde
@@ -202,4 +202,3 @@ class Block {
     }
   }
 }
-

--- a/Enemy.pde
+++ b/Enemy.pde
@@ -18,8 +18,3 @@ class Enemy extends Player {
     }
   }
 }
-
-
-
-
-

--- a/Item.pde
+++ b/Item.pde
@@ -22,8 +22,3 @@ class Item {
     return false;
   }
 }
-
-
-
-
-

--- a/Player.pde
+++ b/Player.pde
@@ -129,4 +129,3 @@ class Player {
     }
   }
 }
-

--- a/superHogeMaker.pde
+++ b/superHogeMaker.pde
@@ -38,13 +38,12 @@ void settings() {
 }
 
 void setup() {
-  //↓シリアル使わないときはコメントアウト
+  //シリアル
   if (Serial.list().length>0) {
     println("serial="+Serial.list());
     serial=new Serial(this, Serial.list()[0], 9600);
     serial.write('a');
   }
-  //↑ここまで
 
   minim = new Minim( this );
   bgm = minim.loadFile( "BGM.mp3" );
@@ -327,9 +326,6 @@ void draw() {
     }
 
     //ブロックの情報取得
-    //シリアル使わないときはコメントアウト
-    //シリアル使うときコメントアウト外すのを忘れずに！
-    //↓ここから…
     if (Serial.list().length>0) {
       if (serial.available()>0 && !move) {
         String str = serial.readStringUntil('e');
@@ -340,7 +336,6 @@ void draw() {
         println("not available");
       }
     }
-    //↑ここまでコメントアウト！
 
     pushMatrix();
     translate(backX, 0);
@@ -379,9 +374,6 @@ void draw() {
     //ブロック
 
     //ブロックの情報取得
-    //シリアル使わないときはコメントアウト
-    //シリアル使うときコメントアウト外すのを忘れずに！
-    //↓ここから…
     if (Serial.list().length>0) {
       if (serial.available()>0 && !move) {
         String str = serial.readStringUntil('e');
@@ -392,7 +384,6 @@ void draw() {
         println("not available");
       }
     }
-    //↑ここまでコメントアウト！
 
     for (int[] b : broken) {
       /*

--- a/superHogeMaker.pde
+++ b/superHogeMaker.pde
@@ -330,13 +330,15 @@ void draw() {
     //シリアル使わないときはコメントアウト
     //シリアル使うときコメントアウト外すのを忘れずに！
     //↓ここから…
-    if (serial.available()>0 && !move) {
-      String str = serial.readStringUntil('e');
-      println(str);
-      block.getSerialData_(str);
-      serial.write('a');
-    } else {
-      println("not available");
+    if (Serial.list().length>0) {
+      if (serial.available()>0 && !move) {
+        String str = serial.readStringUntil('e');
+        println(str);
+        block.getSerialData_(str);
+        serial.write('a');
+      } else {
+        println("not available");
+      }
     }
     //↑ここまでコメントアウト！
 
@@ -380,13 +382,15 @@ void draw() {
     //シリアル使わないときはコメントアウト
     //シリアル使うときコメントアウト外すのを忘れずに！
     //↓ここから…
-    if (serial.available()>0 && !move) {
-      String str = serial.readStringUntil('e');
-      //println(str);
-      block2.getSerialData_battle(str);
-      serial.write('a');
-    } else {
-      println("not available");
+    if (Serial.list().length>0) {
+      if (serial.available()>0 && !move) {
+        String str = serial.readStringUntil('e');
+        //println(str);
+        block2.getSerialData_battle(str);
+        serial.write('a');
+      } else {
+        println("not available");
+      }
     }
     //↑ここまでコメントアウト！
 
@@ -662,6 +666,7 @@ void keyReleased() {
     }
   }
   if (key == 'b') {
+    stop();
     initialize();
   }
 }


### PR DESCRIPTION
シリアル繋いでないとき、つくるモードとこうぼうせんモードでエラーが出るのをなくしました。
ついでに音声のバグ修正。あそぶモード→bボタンでタイトル→こうぼうせん　のような移動をしたとき、BGMが2重に流れる問題を解決。
変更内容
・setup内と同じくif文を追加、「コメントアウト」のコメントを削除
・bボタンでタイトルへ戻るとき再生ストップするのを追加
